### PR TITLE
message is not a valid property of threadFlowLocation

### DIFF
--- a/docs/3-Beyond-basics.md
+++ b/docs/3-Beyond-basics.md
@@ -649,9 +649,6 @@ The tool might produce something like this (see [bad-eval-with-code-flow.sarif](
                 {
                   "locations": [
                     {
-                      "message": {
-                        "text": "The tainted data enters the system here."
-                      },
                       "location": {
                         "physicalLocation": {
                           "artifactLocation": {
@@ -688,9 +685,6 @@ The tool might produce something like this (see [bad-eval-with-code-flow.sarif](
                       "nestingLevel": 0
                     },
                     {
-                      "message": {
-                        "text": "The tainted data is used insecurely here."
-                      },
                       "location": {
                         "physicalLocation": {
                           "artifactLocation": {


### PR DESCRIPTION
I tried to validate the SARIF file of the section [Beyond the basics - Code flows](https://github.com/microsoft/sarif-tutorials/blob/main/docs/3-Beyond-basics.md#code-flows) using https://sarifweb.azurewebsites.net/Validation but it failed.

According to [3.38 threadFlowLocation object](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317751), there is no such `message` property allowed for the `threadFlowLocation` object.

Is it something you plan to add to the spec in the future? I would be interested to add a `message` to a specific thread flow location!