### PR TITLE
Fix wrong position of message in codeFlows.

### DIFF
--- a/docs/3-Beyond-basics.md
+++ b/docs/3-Beyond-basics.md
@@ -649,10 +649,10 @@ The tool might produce something like this (see [bad-eval-with-code-flow.sarif](
                 {
                   "locations": [
                     {
-                      "message": {
-                        "text": "The tainted data enters the system here."
-                      },
                       "location": {
+                        "message": {
+                          "text": "The tainted data enters the system here."
+                        },
                         "physicalLocation": {
                           "artifactLocation": {
                             "uri": "3-Beyond-basics/bad-eval-with-code-flow.py"
@@ -688,10 +688,10 @@ The tool might produce something like this (see [bad-eval-with-code-flow.sarif](
                       "nestingLevel": 0
                     },
                     {
-                      "message": {
-                        "text": "The tainted data is used insecurely here."
-                      },
                       "location": {
+                        "message": {
+                          "text": "The tainted data is used insecurely here."
+                        },
                         "physicalLocation": {
                           "artifactLocation": {
                             "uri": "3-Beyond-basics/bad-eval-with-code-flow.py"


### PR DESCRIPTION
As stated in [PR31](https://github.com/microsoft/sarif-tutorials/pull/31), the original file can not pass validation. 

`codeFlows[0].threadFlows[0].locations[0]` do not allow a `message` property, but this `message` can be moved into `codeFlows[0].threadFlows[0].locations[0].location` according to the [specification: 3.38.3 location property](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317754).