### PR TITLE
Fixed an incorrect representation of "message"

### DIFF
--- a/docs/3-Beyond-basics.md
+++ b/docs/3-Beyond-basics.md
@@ -25,7 +25,9 @@ and might produce a `result` like this (see [bad-eval.sarif](../samples/3-Beyond
 ```json
 {
   "ruleId": "PY2335",
-  "message": "Use of tainted variable 'expr' in the insecure function 'eval'.",
+  "message": {
+    "text": "Use of tainted variable 'expr' in the insecure function 'eval'."
+  },
   "locations": [
     {
       "physicalLocation": {


### PR DESCRIPTION
Reading through I thought this looked off, and looking at the example itself, it looks like there was an editorial error where `message` was changed to a JSON string value rather than a JSON object value.